### PR TITLE
add new readthedocs configuration file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,20 @@
+version: 2
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.9"
+
+sphinx:
+  fail_on_warning: true
+
+python:
+  # Install our python package before building the docs
+  install:
+    - method: pip
+      path: .
+    - requirements: requirements.txt
+
+formats:
+  - pdf
+  - epub


### PR DESCRIPTION
adds a new base readthedocs configuration file to setup documentation which uses python3.9 as build interpreter and fails on warnings